### PR TITLE
Use package.json to allow usage of npm in projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mxgraph",
-    "version": "3.1.2-1",
+    "version": "3.1.2-2",
     "description": "mxGraph is a fully client side JavaScript diagramming library. It is the underlying technology that powers the drawing functionality that you see in https://www.draw.io.",
     "private": true,
     "main": "javascript/mxClient.js",


### PR DESCRIPTION
David, Gaudenz,

I created an example of a package.json file which allows me to include mxgraph for javascript directly via npm.

Now I just need to add the following dependency to my project:

```
  "dependencies": {
    "mxgraph" : "git+ssh://git@github.com/leanix/mxgraph.git",
  }
```

It would be more than great if you would add the package.json to the official distribution - this would then also allow me to specify a specific release by using a tag, e.g.

```
  "dependencies": {
    "mxgraph" : "git+ssh://git@github.com/leanix/mxgraph.git#3.1.2.0",
  }
```

However, one downside stays: Now everytime the entire source incl. PHP, Java, etc etc. is downloaded. Unfortunately npm does not yet allow to include subdirectories via git (only putting package.json into javascript dir). Therefore the ultimate solution would be to have a dedicated repo for javascript only.

Looking forward to learn what you say.

Thx,
André
