### PR TITLE
Create npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+javascript/dist
+.jshintrc
+javascript/examples/**/dist

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,102 @@
+var path = require("path"),
+    fs = require("fs"),
+    mxClientContent,
+    deps;
+
+// To get the dependencies for the project, read the filenames by matching
+// mxClient.include([...]) in mxClient.js. This is not perfect, but the list is
+// required in mxClient.js for compatibility.
+mxClientContent = fs.readFileSync(
+  path.join(__dirname, "./javascript/src/js/mxClient.js"),
+  "utf8"
+);
+deps = mxClientContent.match(/mxClient\.include\([^"']+["'](.*?)["']/gi).map(function (str) {
+  return "." + str.match(/mxClient\.include\([^"']+["'](.*?)["']/)[1];
+});
+deps = ["./js/mxClient.js"].concat(deps.slice(0));
+
+module.exports = function (grunt) {
+  grunt.initConfig({
+    copy: {
+      main: {
+        files: [{
+          expand: true,
+          cwd: "./javascript/src",
+          src: deps,
+          dest: "./javascript/dist"
+        }],
+        options: {
+          // After each module, add the object to the '__mxOutput' namespace
+          // E.g. __mxOutput.mxLog, etc.
+          process: function (content, srcpath) {
+            var afterContent = "",
+                moduleName = path.basename(srcpath, ".js");
+
+            afterContent += "\n__mxOutput." + path.basename(srcpath, ".js") +
+              " = typeof " + moduleName + " !== 'undefined' ? " + moduleName + " : undefined;\n";
+
+            return content + afterContent;
+          }
+        }
+      }
+    },
+    concat: {
+      dist: {
+        src: deps.map(function (dep) {
+          return path.join("./javascript/dist", dep);
+        }),
+        dest: './javascript/dist/build.js'
+      },
+      options: {
+        banner: "(function (root, factory) {\n" +
+          "if (typeof define === 'function' && define.amd) {\n" +
+          "define([], factory);\n" +
+          "} else if (typeof module === 'object' && module.exports) {\n" +
+          "module.exports = factory();\n" +
+          "} else {\n" +
+          "root.mxgraph = factory();\n" +
+          "}\n" +
+          "}(this, function () {\n" +
+          "return function (opts) {\n" +
+          // Opts will be passed into this function, expand them out as if
+          // they were globals so they can get picked up by the logic in
+          // mxClient.js.
+          "for (var name in opts) { this[name] = opts[name]; }\n" +
+          "var __mxOutput = {};\n",
+        footer: "return __mxOutput;\n" +
+          "};\n" +
+          "}));"
+      }
+    },
+    webpack: {
+      examples: {
+        entry: "./javascript/examples/webpack/src/anchors.js",
+        output: {
+          path: "javascript/examples/webpack/dist",
+          filename: "anchors.js"
+        }
+      }
+    },
+    watch: {
+      javascripts: {
+        files: "javascript/src/**/*.js",
+        tasks: ["umdify"],
+        options: {
+          interrupt: true
+        }
+      }
+    },
+  });
+
+  grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-webpack');
+  grunt.loadNpmTasks('grunt-contrib-concat');
+  grunt.registerTask("default", [
+    "copy",
+    "concat",
+    "webpack"
+  ]);
+  grunt.registerTask("build", [
+    "default"
+  ]);
+};

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,6 @@
 var path = require("path"),
     fs = require("fs"),
+    parentFolderName = path.basename(path.resolve('..')),
     mxClientContent,
     deps;
 
@@ -88,9 +89,7 @@ module.exports = function (grunt) {
     },
   });
 
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-webpack');
-  grunt.loadNpmTasks('grunt-contrib-concat');
+  require(parentFolderName === "node_modules" ? "load-grunt-parent-tasks" : "load-grunt-tasks")(grunt);
   grunt.registerTask("default", [
     "copy",
     "concat",

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -59,8 +59,8 @@ individual features of the library.</p>
 <p>Developers integrating the library in their application should
 read the section
 &ldquo;Pre-requisites&rdquo; below. Given that mxGraph is a component
-part of your application, you must understand how JavaScript web 
-applications are constructed at an architectural level, and how to program 
+part of your application, you must understand how JavaScript web
+applications are constructed at an architectural level, and how to program
 both in JavaScript, as well as any server-side languages used.</p>
 
 <p>mxGraph mainly comprises one JavaScript
@@ -117,7 +117,7 @@ application to invoke the library's functionality.</p>
 
 <p>mxGraph uses JavaScript for the client-side functionality on the
 browser. The JavaScript code in turn uses the underlying vector graphics
-language on the active browser to render the displayed diagram, currently SVG 
+language on the active browser to render the displayed diagram, currently SVG
 for all supported browsers. mxGraph also includes the feature to render entirely
 using html, this limits the range of functionality available, but is
 suitable for more simple diagrams.</p>
@@ -131,8 +131,8 @@ browsers and adapts to the inconsistencies behind the scenes.</p>
 
 <h2><a name="mxgraph_licensing"></a>mxGraph Licensing</h2>
 
-<p>The JavaScript client of mxGraph is licensed under the 
-<a href="https://www.apache.org/licenses/LICENSE-2.0"> Apache  
+<p>The JavaScript client of mxGraph is licensed under the
+<a href="https://www.apache.org/licenses/LICENSE-2.0"> Apache
 2.0 license</a> For detailed licensing questions you are always advised to
 consult a legal professional.</p>
 
@@ -272,8 +272,8 @@ abstracts the description of the visual component into one API.</p>
 	<li>Navigate to the <a
 		href="http://www.jgraph.com/mxdownload.html">evaluation download
 	request page</a>.</li>
-	<li>Please note that we require a commercial or organizational email 
-	address to process your request. We're not able to sell mxGraph to 
+	<li>Please note that we require a commercial or organizational email
+	address to process your request. We're not able to sell mxGraph to
 	individuals.</li>
 	<li>When you receive the download details, unzip to your preferred
 	location.</li>
@@ -383,6 +383,30 @@ directories in the installation root.</p>
 
 <p><em>Table: Project Directory Structure</em></p>
 <br/>
+
+<h3><a name="npm"></a>npm</h3>
+
+<p>mxGraph is also available via the npm package manager. To use mxGraph as
+	a depedency, use <code>npm install</code>:</p>
+
+<pre>npm install mxgraph --save</pre>
+
+<p>The module can be loaded using <code>require()</code>. This returns a
+	factory function that accepts an object of options. Options such as
+	<code>mxBasePath</code> must be provided to the factory function, rather
+	than specified as global variables.</p>
+
+<pre>var mxgraph = require("mxgraph")({
+  mxImageBasePath: "./src/images",
+  mxBasePath: "./src"
+})</pre>
+
+<p>The factory function returns a 'namespace object' that provides access to
+	all objects of the mxGraph package. For example, the <code>mxEvent</code>
+	object is available at <code>mxgraph.mxEvent</code>.</p>
+
+<pre>var mxEvent = mxgraph.mxEvent;
+mxEvent.disableContextMenu(container);</pre>
 
 <h2><a name="web_applications"></a>JavaScript and Web Applications</h2>
 

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -59,8 +59,8 @@ individual features of the library.</p>
 <p>Developers integrating the library in their application should
 read the section
 &ldquo;Pre-requisites&rdquo; below. Given that mxGraph is a component
-part of your application, you must understand how JavaScript web
-applications are constructed at an architectural level, and how to program
+part of your application, you must understand how JavaScript web 
+applications are constructed at an architectural level, and how to program 
 both in JavaScript, as well as any server-side languages used.</p>
 
 <p>mxGraph mainly comprises one JavaScript
@@ -117,7 +117,7 @@ application to invoke the library's functionality.</p>
 
 <p>mxGraph uses JavaScript for the client-side functionality on the
 browser. The JavaScript code in turn uses the underlying vector graphics
-language on the active browser to render the displayed diagram, currently SVG
+language on the active browser to render the displayed diagram, currently SVG 
 for all supported browsers. mxGraph also includes the feature to render entirely
 using html, this limits the range of functionality available, but is
 suitable for more simple diagrams.</p>
@@ -131,8 +131,8 @@ browsers and adapts to the inconsistencies behind the scenes.</p>
 
 <h2><a name="mxgraph_licensing"></a>mxGraph Licensing</h2>
 
-<p>The JavaScript client of mxGraph is licensed under the
-<a href="https://www.apache.org/licenses/LICENSE-2.0"> Apache
+<p>The JavaScript client of mxGraph is licensed under the 
+<a href="https://www.apache.org/licenses/LICENSE-2.0"> Apache  
 2.0 license</a> For detailed licensing questions you are always advised to
 consult a legal professional.</p>
 
@@ -272,8 +272,8 @@ abstracts the description of the visual component into one API.</p>
 	<li>Navigate to the <a
 		href="http://www.jgraph.com/mxdownload.html">evaluation download
 	request page</a>.</li>
-	<li>Please note that we require a commercial or organizational email
-	address to process your request. We're not able to sell mxGraph to
+	<li>Please note that we require a commercial or organizational email 
+	address to process your request. We're not able to sell mxGraph to 
 	individuals.</li>
 	<li>When you receive the download details, unzip to your preferred
 	location.</li>

--- a/javascript/examples/webpack/anchors.html
+++ b/javascript/examples/webpack/anchors.html
@@ -1,0 +1,22 @@
+<!--
+  Copyright (c) 2006-2013, JGraph Ltd
+
+  Anchors example for mxGraph. This example demonstrates defining
+  fixed connection points for all shapes.
+-->
+<html>
+<head>
+	<title>Anchors example for mxGraph</title>
+	<!-- Loads and initializes the library -->
+	<script type="text/javascript" src="dist/anchors.js"></script>
+</head>
+
+<!-- Page passes the container for the graph to the program -->
+<body>
+
+	<!-- Creates a container for the graph with a grid wallpaper -->
+	<div id="graphContainer"
+		style="position:relative;overflow:hidden;width:321px;height:241px;background:url('../editors/images/grid.gif');cursor:default;">
+	</div>
+</body>
+</html>

--- a/javascript/examples/webpack/src/anchors.js
+++ b/javascript/examples/webpack/src/anchors.js
@@ -1,0 +1,99 @@
+var mxgraph = require("../../../dist/build")({
+      mxImageBasePath: "../../src/images",
+      mxBasePath: "../../src"
+    }),
+    mxGraph = mxgraph.mxGraph,
+    mxShape = mxgraph.mxShape,
+    mxConnectionConstraint = mxgraph.mxConnectionConstraint,
+    mxPoint = mxgraph.mxPoint,
+    mxPolyline = mxgraph.mxPolyline,
+    mxEvent = mxgraph.mxEvent,
+    mxRubberband = mxgraph.mxRubberband,
+    mxCellState = mxgraph.mxCellState;
+
+window.onload = function () {
+  // Overridden to define per-shape connection points
+  mxGraph.prototype.getAllConnectionConstraints = function(terminal, source)
+  {
+    if (terminal != null && terminal.shape != null)
+    {
+      if (terminal.shape.stencil != null)
+      {
+        if (terminal.shape.stencil != null)
+        {
+          return terminal.shape.stencil.constraints;
+        }
+      }
+      else if (terminal.shape.constraints != null)
+      {
+        return terminal.shape.constraints;
+      }
+    }
+
+    return null;
+  };
+
+  // Defines the default constraints for all shapes
+  mxShape.prototype.constraints = [new mxConnectionConstraint(new mxPoint(0.25, 0), true),
+                   new mxConnectionConstraint(new mxPoint(0.5, 0), true),
+                   new mxConnectionConstraint(new mxPoint(0.75, 0), true),
+                               new mxConnectionConstraint(new mxPoint(0, 0.25), true),
+                               new mxConnectionConstraint(new mxPoint(0, 0.5), true),
+                               new mxConnectionConstraint(new mxPoint(0, 0.75), true),
+                             new mxConnectionConstraint(new mxPoint(1, 0.25), true),
+                             new mxConnectionConstraint(new mxPoint(1, 0.5), true),
+                             new mxConnectionConstraint(new mxPoint(1, 0.75), true),
+                             new mxConnectionConstraint(new mxPoint(0.25, 1), true),
+                             new mxConnectionConstraint(new mxPoint(0.5, 1), true),
+                             new mxConnectionConstraint(new mxPoint(0.75, 1), true)];
+
+  // Edges have no connection points
+  mxPolyline.prototype.constraints = null;
+
+  // Program starts here. Creates a sample graph in the
+  // DOM node with the specified ID. This function is invoked
+  // from the onLoad event handler of the document (see below).
+  function main(container)
+  {
+    // Disables the built-in context menu
+    mxEvent.disableContextMenu(container);
+
+    // Creates the graph inside the given container
+    var graph = new mxGraph(container);
+    graph.setConnectable(true);
+
+    // Enables connect preview for the default edge style
+    graph.connectionHandler.createEdgeState = function(me)
+    {
+      var edge = graph.createEdge(null, null, null, null, null);
+
+      return new mxCellState(this.graph.view, edge, this.graph.getCellStyle(edge));
+    };
+
+    // Specifies the default edge style
+    graph.getStylesheet().getDefaultEdgeStyle()['edgeStyle'] = 'orthogonalEdgeStyle';
+
+    // Enables rubberband selection
+    new mxRubberband(graph);
+
+    // Gets the default parent for inserting new cells. This
+    // is normally the first child of the root (ie. layer 0).
+    var parent = graph.getDefaultParent();
+
+    // Adds cells to the model in a single step
+    graph.getModel().beginUpdate();
+    try
+    {
+      var v1 = graph.insertVertex(parent, null, 'Hello,', 20, 20, 80, 30);
+      var v2 = graph.insertVertex(parent, null, 'World!', 200, 150, 80, 30);
+      var e1 = graph.insertEdge(parent, null, '', v1, v2);
+    }
+    finally
+    {
+      // Updates the display
+      graph.getModel().endUpdate();
+    }
+  };
+
+  main(document.getElementById('graphContainer'));
+};

--- a/javascript/src/js/mxClient.js
+++ b/javascript/src/js/mxClient.js
@@ -12,14 +12,14 @@ var mxClient =
 	 * well as global constants to identify the browser and operating system in
 	 * use. You may have to load chrome://global/content/contentAreaUtils.js in
 	 * your page to disable certain security restrictions in Mozilla.
-	 *
+	 * 
 	 * Variable: VERSION
 	 *
 	 * Contains the current version of the mxGraph library. The strings that
 	 * communicate versions of mxGraph use the following format.
-	 *
+	 * 
 	 * versionMajor.versionMinor.buildNumber.revisionNumber
-	 *
+	 * 
 	 * Current version is 3.7.1.
 	 */
 	VERSION: '3.7.1',
@@ -62,21 +62,21 @@ var mxClient =
 
 	/**
 	 * Variable: IS_EM
-	 *
+	 * 
 	 * True if the browser is IE11 in enterprise mode (IE8 standards mode).
 	 */
 	IS_EM: 'spellcheck' in document.createElement('textarea') && document.documentMode == 8,
 
 	/**
 	 * Variable: VML_PREFIX
-	 *
+	 * 
 	 * Prefix for VML namespace in node names. Default is 'v'.
 	 */
 	VML_PREFIX: 'v',
 
 	/**
 	 * Variable: OFFICE_PREFIX
-	 *
+	 * 
 	 * Prefix for VML office namespace in node names. Default is 'o'.
 	 */
 	OFFICE_PREFIX: 'o',
@@ -111,7 +111,7 @@ var mxClient =
   		navigator.userAgent.indexOf('Presto/2.1.') < 0 &&
   		navigator.userAgent.indexOf('Presto/2.0.') < 0 &&
   		navigator.userAgent.indexOf('Presto/1.') < 0,
-
+  	
 	/**
 	 * Variable: IS_SF
 	 *
@@ -120,14 +120,14 @@ var mxClient =
   	IS_SF: navigator.userAgent.indexOf('AppleWebKit/') >= 0 &&
   		navigator.userAgent.indexOf('Chrome/') < 0 &&
   		navigator.userAgent.indexOf('Edge/') < 0,
-
+  	
 	/**
 	 * Variable: IS_IOS
-	 *
+	 * 
 	 * Returns true if the user agent is an iPad, iPhone or iPod.
 	 */
   	IS_IOS: (navigator.userAgent.match(/(iPad|iPhone|iPod)/g) ? true : false),
-
+  		
 	/**
 	 * Variable: IS_GC
 	 *
@@ -135,21 +135,21 @@ var mxClient =
 	 */
   	IS_GC: navigator.userAgent.indexOf('Chrome/') >= 0 &&
 		navigator.userAgent.indexOf('Edge/') < 0,
-
+	
 	/**
 	 * Variable: IS_CHROMEAPP
 	 *
 	 * True if the this is running inside a Chrome App.
 	 */
   	IS_CHROMEAPP: window.chrome != null && chrome.app != null && chrome.app.runtime != null,
-
+		
 	/**
 	 * Variable: IS_FF
 	 *
 	 * True if the current browser is Firefox.
 	 */
   	IS_FF: navigator.userAgent.indexOf('Firefox/') >= 0,
-
+  	
 	/**
 	 * Variable: IS_MT
 	 *
@@ -216,7 +216,7 @@ var mxClient =
 
 	/**
 	 * Variable: IS_TOUCH
-	 *
+	 * 
 	 * True if this device supports touchstart/-move/-end events (Apple iOS,
 	 * Android, Chromebook and Chrome Browser on touch-enabled devices).
 	 */
@@ -224,7 +224,7 @@ var mxClient =
 
 	/**
 	 * Variable: IS_POINTER
-	 *
+	 * 
 	 * True if this device supports Microsoft pointer events (always false on Macs).
 	 */
   	IS_POINTER: window.PointerEvent != null && !(navigator.appVersion.indexOf('Mac') > 0),
@@ -242,9 +242,9 @@ var mxClient =
 	 *
 	 * Returns true if the current browser is supported, that is, if
 	 * <mxClient.IS_VML> or <mxClient.IS_SVG> is true.
-	 *
+	 * 
 	 * Example:
-	 *
+	 * 
 	 * (code)
 	 * if (!mxClient.isBrowserSupported())
 	 * {
@@ -269,9 +269,9 @@ var mxClient =
 	 *
 	 * where filename is the (relative) URL of the stylesheet. The charset
 	 * is hardcoded to ISO-8859-1 and the type is text/css.
-	 *
+	 * 
 	 * Parameters:
-	 *
+	 * 
 	 * rel - String that represents the rel attribute of the link node.
 	 * href - String that represents the href attribute of the link node.
 	 * doc - Optional parent document of the link node.
@@ -286,24 +286,24 @@ var mxClient =
 			doc.write('<link rel="' + rel + '" href="' + href + '" charset="UTF-8" type="text/css"/>');
 		}
 		else
-		{
+		{	
 			var link = doc.createElement('link');
-
+			
 			link.setAttribute('rel', rel);
 			link.setAttribute('href', href);
 			link.setAttribute('charset', 'UTF-8');
 			link.setAttribute('type', 'text/css');
-
+			
 			var head = doc.getElementsByTagName('head')[0];
 	   		head.appendChild(link);
 		}
 	},
-
+	
 	/**
 	 * Function: include
 	 *
 	 * Dynamically adds a script node to the document header.
-	 *
+	 * 
 	 * In production environments, the includes are resolved in the mxClient.js
 	 * file to reduce the number of requests required for client startup. This
 	 * function should only be used in development environments, but not in
@@ -313,10 +313,10 @@ var mxClient =
 	{
 		document.write('<script src="'+src+'"></script>');
 	},
-
+	
 	/**
 	 * Function: dispose
-	 *
+	 * 
 	 * Frees up memory in IE by resolving cyclic dependencies between the DOM
 	 * and the JavaScript objects.
 	 */
@@ -336,7 +336,7 @@ var mxClient =
 
 /**
  * Variable: mxLoadResources
- *
+ * 
  * Optional global config variable to toggle loading of the two resource files
  * in <mxGraph> and <mxEditor>. Default is true. NOTE: This is a global variable,
  * not a variable of mxClient.
@@ -355,7 +355,7 @@ if (typeof(mxLoadResources) == 'undefined')
 
 /**
  * Variable: mxResourceExtension
- *
+ * 
  * Optional global config variable to specify the extension of resource files.
  * Default is true. NOTE: This is a global variable, not a variable of mxClient.
  *
@@ -373,7 +373,7 @@ if (typeof(mxResourceExtension) == 'undefined')
 
 /**
  * Variable: mxLoadStylesheets
- *
+ * 
  * Optional global config variable to toggle loading of the CSS files when
  * the library is initialized. Default is true. NOTE: This is a global variable,
  * not a variable of mxClient.
@@ -403,7 +403,7 @@ if (typeof(mxLoadStylesheets) == 'undefined')
  * </script>
  * <script type="text/javascript" src="/path/to/core/directory/js/mxClient.js"></script>
  * (end)
- *
+ * 
  * When using a relative path, the path is relative to the URL of the page that
  * contains the assignment. Trailing slashes are automatically removed.
  */
@@ -435,7 +435,7 @@ else
  * </script>
  * <script type="text/javascript" src="/path/to/core/directory/js/mxClient.js"></script>
  * (end)
- *
+ * 
  * When using a relative path, the path is relative to the URL of the page that
  * contains the assignment. Trailing slashes are automatically removed.
  */
@@ -451,7 +451,7 @@ if (typeof(mxImageBasePath) != 'undefined' && mxImageBasePath.length > 0)
 }
 else
 {
-	mxClient.imageBasePath = mxClient.basePath + '/images';
+	mxClient.imageBasePath = mxClient.basePath + '/images';	
 }
 
 /**
@@ -461,7 +461,7 @@ else
  * The special value 'none' will disable all built-in internationalization and
  * resource loading. See <mxResources.getSpecialBundle> for handling identifiers
  * with and without a dash.
- *
+ * 
  * Set mxLanguage prior to loading the mxClient library as follows to override
  * this setting:
  *
@@ -471,7 +471,7 @@ else
  * </script>
  * <script type="text/javascript" src="js/mxClient.js"></script>
  * (end)
- *
+ * 
  * If internationalization is disabled, then the following variables should be
  * overridden to reflect the current language of the system. These variables are
  * cleared when i18n is disabled.
@@ -496,11 +496,11 @@ else
 
 /**
  * Variable: defaultLanguage
- *
+ * 
  * Defines the default language which is used in the common resource files. Any
  * resources for this language will only load the common resource file, but not
  * the language-specific resource file. Default is 'en'.
- *
+ * 
  * Set mxDefaultLanguage prior to loading the mxClient library as follows to override
  * this setting:
  *
@@ -539,7 +539,7 @@ if (mxLoadStylesheets)
  * </script>
  * <script type="text/javascript" src="js/mxClient.js"></script>
  * (end)
- *
+ * 
  * This is used to avoid unnecessary requests to language files, ie. if a 404
  * will be returned.
  */
@@ -588,12 +588,12 @@ if (mxClient.IS_VML)
 			document.createStyleSheet().cssText = mxClient.VML_PREFIX + '\\:*{behavior:url(#default#VML)}' +
 		    	mxClient.OFFICE_PREFIX + '\\:*{behavior:url(#default#VML)}';
 		}
-
+	    
 	    if (mxLoadStylesheets)
 	    {
 	    	mxClient.link('stylesheet', mxClient.basePath + '/css/explorer.css');
 	    }
-
+	
 		// Cleans up resources when the application terminates
 		window.attachEvent('onunload', mxClient.dispose);
 	}

--- a/javascript/src/js/mxClient.js
+++ b/javascript/src/js/mxClient.js
@@ -12,14 +12,14 @@ var mxClient =
 	 * well as global constants to identify the browser and operating system in
 	 * use. You may have to load chrome://global/content/contentAreaUtils.js in
 	 * your page to disable certain security restrictions in Mozilla.
-	 * 
+	 *
 	 * Variable: VERSION
 	 *
 	 * Contains the current version of the mxGraph library. The strings that
 	 * communicate versions of mxGraph use the following format.
-	 * 
+	 *
 	 * versionMajor.versionMinor.buildNumber.revisionNumber
-	 * 
+	 *
 	 * Current version is 3.7.1.
 	 */
 	VERSION: '3.7.1',
@@ -62,21 +62,21 @@ var mxClient =
 
 	/**
 	 * Variable: IS_EM
-	 * 
+	 *
 	 * True if the browser is IE11 in enterprise mode (IE8 standards mode).
 	 */
 	IS_EM: 'spellcheck' in document.createElement('textarea') && document.documentMode == 8,
 
 	/**
 	 * Variable: VML_PREFIX
-	 * 
+	 *
 	 * Prefix for VML namespace in node names. Default is 'v'.
 	 */
 	VML_PREFIX: 'v',
 
 	/**
 	 * Variable: OFFICE_PREFIX
-	 * 
+	 *
 	 * Prefix for VML office namespace in node names. Default is 'o'.
 	 */
 	OFFICE_PREFIX: 'o',
@@ -111,7 +111,7 @@ var mxClient =
   		navigator.userAgent.indexOf('Presto/2.1.') < 0 &&
   		navigator.userAgent.indexOf('Presto/2.0.') < 0 &&
   		navigator.userAgent.indexOf('Presto/1.') < 0,
-  	
+
 	/**
 	 * Variable: IS_SF
 	 *
@@ -120,14 +120,14 @@ var mxClient =
   	IS_SF: navigator.userAgent.indexOf('AppleWebKit/') >= 0 &&
   		navigator.userAgent.indexOf('Chrome/') < 0 &&
   		navigator.userAgent.indexOf('Edge/') < 0,
-  	
+
 	/**
 	 * Variable: IS_IOS
-	 * 
+	 *
 	 * Returns true if the user agent is an iPad, iPhone or iPod.
 	 */
   	IS_IOS: (navigator.userAgent.match(/(iPad|iPhone|iPod)/g) ? true : false),
-  		
+
 	/**
 	 * Variable: IS_GC
 	 *
@@ -135,21 +135,21 @@ var mxClient =
 	 */
   	IS_GC: navigator.userAgent.indexOf('Chrome/') >= 0 &&
 		navigator.userAgent.indexOf('Edge/') < 0,
-	
+
 	/**
 	 * Variable: IS_CHROMEAPP
 	 *
 	 * True if the this is running inside a Chrome App.
 	 */
   	IS_CHROMEAPP: window.chrome != null && chrome.app != null && chrome.app.runtime != null,
-		
+
 	/**
 	 * Variable: IS_FF
 	 *
 	 * True if the current browser is Firefox.
 	 */
   	IS_FF: navigator.userAgent.indexOf('Firefox/') >= 0,
-  	
+
 	/**
 	 * Variable: IS_MT
 	 *
@@ -216,7 +216,7 @@ var mxClient =
 
 	/**
 	 * Variable: IS_TOUCH
-	 * 
+	 *
 	 * True if this device supports touchstart/-move/-end events (Apple iOS,
 	 * Android, Chromebook and Chrome Browser on touch-enabled devices).
 	 */
@@ -224,7 +224,7 @@ var mxClient =
 
 	/**
 	 * Variable: IS_POINTER
-	 * 
+	 *
 	 * True if this device supports Microsoft pointer events (always false on Macs).
 	 */
   	IS_POINTER: window.PointerEvent != null && !(navigator.appVersion.indexOf('Mac') > 0),
@@ -242,9 +242,9 @@ var mxClient =
 	 *
 	 * Returns true if the current browser is supported, that is, if
 	 * <mxClient.IS_VML> or <mxClient.IS_SVG> is true.
-	 * 
+	 *
 	 * Example:
-	 * 
+	 *
 	 * (code)
 	 * if (!mxClient.isBrowserSupported())
 	 * {
@@ -269,9 +269,9 @@ var mxClient =
 	 *
 	 * where filename is the (relative) URL of the stylesheet. The charset
 	 * is hardcoded to ISO-8859-1 and the type is text/css.
-	 * 
+	 *
 	 * Parameters:
-	 * 
+	 *
 	 * rel - String that represents the rel attribute of the link node.
 	 * href - String that represents the href attribute of the link node.
 	 * doc - Optional parent document of the link node.
@@ -286,24 +286,24 @@ var mxClient =
 			doc.write('<link rel="' + rel + '" href="' + href + '" charset="UTF-8" type="text/css"/>');
 		}
 		else
-		{	
+		{
 			var link = doc.createElement('link');
-			
+
 			link.setAttribute('rel', rel);
 			link.setAttribute('href', href);
 			link.setAttribute('charset', 'UTF-8');
 			link.setAttribute('type', 'text/css');
-			
+
 			var head = doc.getElementsByTagName('head')[0];
 	   		head.appendChild(link);
 		}
 	},
-	
+
 	/**
 	 * Function: include
 	 *
 	 * Dynamically adds a script node to the document header.
-	 * 
+	 *
 	 * In production environments, the includes are resolved in the mxClient.js
 	 * file to reduce the number of requests required for client startup. This
 	 * function should only be used in development environments, but not in
@@ -313,10 +313,10 @@ var mxClient =
 	{
 		document.write('<script src="'+src+'"></script>');
 	},
-	
+
 	/**
 	 * Function: dispose
-	 * 
+	 *
 	 * Frees up memory in IE by resolving cyclic dependencies between the DOM
 	 * and the JavaScript objects.
 	 */
@@ -336,7 +336,7 @@ var mxClient =
 
 /**
  * Variable: mxLoadResources
- * 
+ *
  * Optional global config variable to toggle loading of the two resource files
  * in <mxGraph> and <mxEditor>. Default is true. NOTE: This is a global variable,
  * not a variable of mxClient.
@@ -355,7 +355,7 @@ if (typeof(mxLoadResources) == 'undefined')
 
 /**
  * Variable: mxResourceExtension
- * 
+ *
  * Optional global config variable to specify the extension of resource files.
  * Default is true. NOTE: This is a global variable, not a variable of mxClient.
  *
@@ -373,7 +373,7 @@ if (typeof(mxResourceExtension) == 'undefined')
 
 /**
  * Variable: mxLoadStylesheets
- * 
+ *
  * Optional global config variable to toggle loading of the CSS files when
  * the library is initialized. Default is true. NOTE: This is a global variable,
  * not a variable of mxClient.
@@ -403,7 +403,7 @@ if (typeof(mxLoadStylesheets) == 'undefined')
  * </script>
  * <script type="text/javascript" src="/path/to/core/directory/js/mxClient.js"></script>
  * (end)
- * 
+ *
  * When using a relative path, the path is relative to the URL of the page that
  * contains the assignment. Trailing slashes are automatically removed.
  */
@@ -435,7 +435,7 @@ else
  * </script>
  * <script type="text/javascript" src="/path/to/core/directory/js/mxClient.js"></script>
  * (end)
- * 
+ *
  * When using a relative path, the path is relative to the URL of the page that
  * contains the assignment. Trailing slashes are automatically removed.
  */
@@ -451,7 +451,7 @@ if (typeof(mxImageBasePath) != 'undefined' && mxImageBasePath.length > 0)
 }
 else
 {
-	mxClient.imageBasePath = mxClient.basePath + '/images';	
+	mxClient.imageBasePath = mxClient.basePath + '/images';
 }
 
 /**
@@ -461,7 +461,7 @@ else
  * The special value 'none' will disable all built-in internationalization and
  * resource loading. See <mxResources.getSpecialBundle> for handling identifiers
  * with and without a dash.
- * 
+ *
  * Set mxLanguage prior to loading the mxClient library as follows to override
  * this setting:
  *
@@ -471,7 +471,7 @@ else
  * </script>
  * <script type="text/javascript" src="js/mxClient.js"></script>
  * (end)
- * 
+ *
  * If internationalization is disabled, then the following variables should be
  * overridden to reflect the current language of the system. These variables are
  * cleared when i18n is disabled.
@@ -496,11 +496,11 @@ else
 
 /**
  * Variable: defaultLanguage
- * 
+ *
  * Defines the default language which is used in the common resource files. Any
  * resources for this language will only load the common resource file, but not
  * the language-specific resource file. Default is 'en'.
- * 
+ *
  * Set mxDefaultLanguage prior to loading the mxClient library as follows to override
  * this setting:
  *
@@ -539,7 +539,7 @@ if (mxLoadStylesheets)
  * </script>
  * <script type="text/javascript" src="js/mxClient.js"></script>
  * (end)
- * 
+ *
  * This is used to avoid unnecessary requests to language files, ie. if a 404
  * will be returned.
  */
@@ -588,154 +588,158 @@ if (mxClient.IS_VML)
 			document.createStyleSheet().cssText = mxClient.VML_PREFIX + '\\:*{behavior:url(#default#VML)}' +
 		    	mxClient.OFFICE_PREFIX + '\\:*{behavior:url(#default#VML)}';
 		}
-	    
+
 	    if (mxLoadStylesheets)
 	    {
 	    	mxClient.link('stylesheet', mxClient.basePath + '/css/explorer.css');
 	    }
-	
+
 		// Cleans up resources when the application terminates
 		window.attachEvent('onunload', mxClient.dispose);
 	}
 }
 
-mxClient.include(mxClient.basePath+'/js/util/mxLog.js');
-mxClient.include(mxClient.basePath+'/js/util/mxObjectIdentity.js');
-mxClient.include(mxClient.basePath+'/js/util/mxDictionary.js');
-mxClient.include(mxClient.basePath+'/js/util/mxResources.js');
-mxClient.include(mxClient.basePath+'/js/util/mxPoint.js');
-mxClient.include(mxClient.basePath+'/js/util/mxRectangle.js');
-mxClient.include(mxClient.basePath+'/js/util/mxEffects.js');
-mxClient.include(mxClient.basePath+'/js/util/mxUtils.js');
-mxClient.include(mxClient.basePath+'/js/util/mxConstants.js');
-mxClient.include(mxClient.basePath+'/js/util/mxEventObject.js');
-mxClient.include(mxClient.basePath+'/js/util/mxMouseEvent.js');
-mxClient.include(mxClient.basePath+'/js/util/mxEventSource.js');
-mxClient.include(mxClient.basePath+'/js/util/mxEvent.js');
-mxClient.include(mxClient.basePath+'/js/util/mxXmlRequest.js');
-mxClient.include(mxClient.basePath+'/js/util/mxClipboard.js');
-mxClient.include(mxClient.basePath+'/js/util/mxWindow.js');
-mxClient.include(mxClient.basePath+'/js/util/mxForm.js');
-mxClient.include(mxClient.basePath+'/js/util/mxImage.js');
-mxClient.include(mxClient.basePath+'/js/util/mxDivResizer.js');
-mxClient.include(mxClient.basePath+'/js/util/mxDragSource.js');
-mxClient.include(mxClient.basePath+'/js/util/mxToolbar.js');
-mxClient.include(mxClient.basePath+'/js/util/mxUndoableEdit.js');
-mxClient.include(mxClient.basePath+'/js/util/mxUndoManager.js');
-mxClient.include(mxClient.basePath+'/js/util/mxUrlConverter.js');
-mxClient.include(mxClient.basePath+'/js/util/mxPanningManager.js');
-mxClient.include(mxClient.basePath+'/js/util/mxPopupMenu.js');
-mxClient.include(mxClient.basePath+'/js/util/mxAutoSaveManager.js');
-mxClient.include(mxClient.basePath+'/js/util/mxAnimation.js');
-mxClient.include(mxClient.basePath+'/js/util/mxMorphing.js');
-mxClient.include(mxClient.basePath+'/js/util/mxImageBundle.js');
-mxClient.include(mxClient.basePath+'/js/util/mxImageExport.js');
-mxClient.include(mxClient.basePath+'/js/util/mxAbstractCanvas2D.js');
-mxClient.include(mxClient.basePath+'/js/util/mxXmlCanvas2D.js');
-mxClient.include(mxClient.basePath+'/js/util/mxSvgCanvas2D.js');
-mxClient.include(mxClient.basePath+'/js/util/mxVmlCanvas2D.js');
-mxClient.include(mxClient.basePath+'/js/util/mxGuide.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxStencil.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxShape.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxStencilRegistry.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxMarker.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxActor.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxCloud.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxRectangleShape.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxEllipse.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxDoubleEllipse.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxRhombus.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxPolyline.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxArrow.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxArrowConnector.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxText.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxTriangle.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxHexagon.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxLine.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxImageShape.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxLabel.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxCylinder.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxConnector.js');
-mxClient.include(mxClient.basePath+'/js/shape/mxSwimlane.js');
-mxClient.include(mxClient.basePath+'/js/layout/mxGraphLayout.js');
-mxClient.include(mxClient.basePath+'/js/layout/mxStackLayout.js');
-mxClient.include(mxClient.basePath+'/js/layout/mxPartitionLayout.js');
-mxClient.include(mxClient.basePath+'/js/layout/mxCompactTreeLayout.js');
-mxClient.include(mxClient.basePath+'/js/layout/mxRadialTreeLayout.js');
-mxClient.include(mxClient.basePath+'/js/layout/mxFastOrganicLayout.js');
-mxClient.include(mxClient.basePath+'/js/layout/mxCircleLayout.js');
-mxClient.include(mxClient.basePath+'/js/layout/mxParallelEdgeLayout.js');
-mxClient.include(mxClient.basePath+'/js/layout/mxCompositeLayout.js');
-mxClient.include(mxClient.basePath+'/js/layout/mxEdgeLabelLayout.js');
-mxClient.include(mxClient.basePath+'/js/layout/hierarchical/model/mxGraphAbstractHierarchyCell.js');
-mxClient.include(mxClient.basePath+'/js/layout/hierarchical/model/mxGraphHierarchyNode.js');
-mxClient.include(mxClient.basePath+'/js/layout/hierarchical/model/mxGraphHierarchyEdge.js');
-mxClient.include(mxClient.basePath+'/js/layout/hierarchical/model/mxGraphHierarchyModel.js');
-mxClient.include(mxClient.basePath+'/js/layout/hierarchical/model/mxSwimlaneModel.js');
-mxClient.include(mxClient.basePath+'/js/layout/hierarchical/stage/mxHierarchicalLayoutStage.js');
-mxClient.include(mxClient.basePath+'/js/layout/hierarchical/stage/mxMedianHybridCrossingReduction.js');
-mxClient.include(mxClient.basePath+'/js/layout/hierarchical/stage/mxMinimumCycleRemover.js');
-mxClient.include(mxClient.basePath+'/js/layout/hierarchical/stage/mxCoordinateAssignment.js');
-mxClient.include(mxClient.basePath+'/js/layout/hierarchical/stage/mxSwimlaneOrdering.js');
-mxClient.include(mxClient.basePath+'/js/layout/hierarchical/mxHierarchicalLayout.js');
-mxClient.include(mxClient.basePath+'/js/layout/hierarchical/mxSwimlaneLayout.js');
-mxClient.include(mxClient.basePath+'/js/model/mxGraphModel.js');
-mxClient.include(mxClient.basePath+'/js/model/mxCell.js');
-mxClient.include(mxClient.basePath+'/js/model/mxGeometry.js');
-mxClient.include(mxClient.basePath+'/js/model/mxCellPath.js');
-mxClient.include(mxClient.basePath+'/js/view/mxPerimeter.js');
-mxClient.include(mxClient.basePath+'/js/view/mxPrintPreview.js');
-mxClient.include(mxClient.basePath+'/js/view/mxStylesheet.js');
-mxClient.include(mxClient.basePath+'/js/view/mxCellState.js');
-mxClient.include(mxClient.basePath+'/js/view/mxGraphSelectionModel.js');
-mxClient.include(mxClient.basePath+'/js/view/mxCellEditor.js');
-mxClient.include(mxClient.basePath+'/js/view/mxCellRenderer.js');
-mxClient.include(mxClient.basePath+'/js/view/mxEdgeStyle.js');
-mxClient.include(mxClient.basePath+'/js/view/mxStyleRegistry.js');
-mxClient.include(mxClient.basePath+'/js/view/mxGraphView.js');
-mxClient.include(mxClient.basePath+'/js/view/mxGraph.js');
-mxClient.include(mxClient.basePath+'/js/view/mxCellOverlay.js');
-mxClient.include(mxClient.basePath+'/js/view/mxOutline.js');
-mxClient.include(mxClient.basePath+'/js/view/mxMultiplicity.js');
-mxClient.include(mxClient.basePath+'/js/view/mxLayoutManager.js');
-mxClient.include(mxClient.basePath+'/js/view/mxSwimlaneManager.js');
-mxClient.include(mxClient.basePath+'/js/view/mxTemporaryCellStates.js');
-mxClient.include(mxClient.basePath+'/js/view/mxCellStatePreview.js');
-mxClient.include(mxClient.basePath+'/js/view/mxConnectionConstraint.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxGraphHandler.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxPanningHandler.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxPopupMenuHandler.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxCellMarker.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxSelectionCellsHandler.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxConnectionHandler.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxConstraintHandler.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxRubberband.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxHandle.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxVertexHandler.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxEdgeHandler.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxElbowEdgeHandler.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxEdgeSegmentHandler.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxKeyHandler.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxTooltipHandler.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxCellTracker.js');
-mxClient.include(mxClient.basePath+'/js/handler/mxCellHighlight.js');
-mxClient.include(mxClient.basePath+'/js/editor/mxDefaultKeyHandler.js');
-mxClient.include(mxClient.basePath+'/js/editor/mxDefaultPopupMenu.js');
-mxClient.include(mxClient.basePath+'/js/editor/mxDefaultToolbar.js');
-mxClient.include(mxClient.basePath+'/js/editor/mxEditor.js');
-mxClient.include(mxClient.basePath+'/js/io/mxCodecRegistry.js');
-mxClient.include(mxClient.basePath+'/js/io/mxCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxObjectCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxCellCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxModelCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxRootChangeCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxChildChangeCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxTerminalChangeCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxGenericChangeCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxGraphCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxGraphViewCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxStylesheetCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxDefaultKeyHandlerCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxDefaultToolbarCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxDefaultPopupMenuCodec.js');
-mxClient.include(mxClient.basePath+'/js/io/mxEditorCodec.js');
+// If script is loaded via CommonJS, do not write <script> tags to the page
+// for dependencies. These are already included in the build.
+if (!(typeof module === 'object' && module.exports)) {
+	mxClient.include(mxClient.basePath+'/js/util/mxLog.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxObjectIdentity.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxDictionary.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxResources.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxPoint.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxRectangle.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxEffects.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxUtils.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxConstants.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxEventObject.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxMouseEvent.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxEventSource.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxEvent.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxXmlRequest.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxClipboard.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxWindow.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxForm.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxImage.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxDivResizer.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxDragSource.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxToolbar.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxUndoableEdit.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxUndoManager.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxUrlConverter.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxPanningManager.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxPopupMenu.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxAutoSaveManager.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxAnimation.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxMorphing.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxImageBundle.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxImageExport.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxAbstractCanvas2D.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxXmlCanvas2D.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxSvgCanvas2D.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxVmlCanvas2D.js');
+	mxClient.include(mxClient.basePath+'/js/util/mxGuide.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxStencil.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxShape.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxStencilRegistry.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxMarker.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxActor.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxCloud.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxRectangleShape.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxEllipse.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxDoubleEllipse.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxRhombus.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxPolyline.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxArrow.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxArrowConnector.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxText.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxTriangle.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxHexagon.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxLine.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxImageShape.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxLabel.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxCylinder.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxConnector.js');
+	mxClient.include(mxClient.basePath+'/js/shape/mxSwimlane.js');
+	mxClient.include(mxClient.basePath+'/js/layout/mxGraphLayout.js');
+	mxClient.include(mxClient.basePath+'/js/layout/mxStackLayout.js');
+	mxClient.include(mxClient.basePath+'/js/layout/mxPartitionLayout.js');
+	mxClient.include(mxClient.basePath+'/js/layout/mxCompactTreeLayout.js');
+	mxClient.include(mxClient.basePath+'/js/layout/mxRadialTreeLayout.js');
+	mxClient.include(mxClient.basePath+'/js/layout/mxFastOrganicLayout.js');
+	mxClient.include(mxClient.basePath+'/js/layout/mxCircleLayout.js');
+	mxClient.include(mxClient.basePath+'/js/layout/mxParallelEdgeLayout.js');
+	mxClient.include(mxClient.basePath+'/js/layout/mxCompositeLayout.js');
+	mxClient.include(mxClient.basePath+'/js/layout/mxEdgeLabelLayout.js');
+	mxClient.include(mxClient.basePath+'/js/layout/hierarchical/model/mxGraphAbstractHierarchyCell.js');
+	mxClient.include(mxClient.basePath+'/js/layout/hierarchical/model/mxGraphHierarchyNode.js');
+	mxClient.include(mxClient.basePath+'/js/layout/hierarchical/model/mxGraphHierarchyEdge.js');
+	mxClient.include(mxClient.basePath+'/js/layout/hierarchical/model/mxGraphHierarchyModel.js');
+	mxClient.include(mxClient.basePath+'/js/layout/hierarchical/model/mxSwimlaneModel.js');
+	mxClient.include(mxClient.basePath+'/js/layout/hierarchical/stage/mxHierarchicalLayoutStage.js');
+	mxClient.include(mxClient.basePath+'/js/layout/hierarchical/stage/mxMedianHybridCrossingReduction.js');
+	mxClient.include(mxClient.basePath+'/js/layout/hierarchical/stage/mxMinimumCycleRemover.js');
+	mxClient.include(mxClient.basePath+'/js/layout/hierarchical/stage/mxCoordinateAssignment.js');
+	mxClient.include(mxClient.basePath+'/js/layout/hierarchical/stage/mxSwimlaneOrdering.js');
+	mxClient.include(mxClient.basePath+'/js/layout/hierarchical/mxHierarchicalLayout.js');
+	mxClient.include(mxClient.basePath+'/js/layout/hierarchical/mxSwimlaneLayout.js');
+	mxClient.include(mxClient.basePath+'/js/model/mxGraphModel.js');
+	mxClient.include(mxClient.basePath+'/js/model/mxCell.js');
+	mxClient.include(mxClient.basePath+'/js/model/mxGeometry.js');
+	mxClient.include(mxClient.basePath+'/js/model/mxCellPath.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxPerimeter.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxPrintPreview.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxStylesheet.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxCellState.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxGraphSelectionModel.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxCellEditor.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxCellRenderer.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxEdgeStyle.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxStyleRegistry.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxGraphView.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxGraph.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxCellOverlay.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxOutline.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxMultiplicity.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxLayoutManager.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxSwimlaneManager.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxTemporaryCellStates.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxCellStatePreview.js');
+	mxClient.include(mxClient.basePath+'/js/view/mxConnectionConstraint.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxGraphHandler.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxPanningHandler.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxPopupMenuHandler.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxCellMarker.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxSelectionCellsHandler.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxConnectionHandler.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxConstraintHandler.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxRubberband.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxHandle.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxVertexHandler.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxEdgeHandler.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxElbowEdgeHandler.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxEdgeSegmentHandler.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxKeyHandler.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxTooltipHandler.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxCellTracker.js');
+	mxClient.include(mxClient.basePath+'/js/handler/mxCellHighlight.js');
+	mxClient.include(mxClient.basePath+'/js/editor/mxDefaultKeyHandler.js');
+	mxClient.include(mxClient.basePath+'/js/editor/mxDefaultPopupMenu.js');
+	mxClient.include(mxClient.basePath+'/js/editor/mxDefaultToolbar.js');
+	mxClient.include(mxClient.basePath+'/js/editor/mxEditor.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxCodecRegistry.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxObjectCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxCellCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxModelCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxRootChangeCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxChildChangeCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxTerminalChangeCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxGenericChangeCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxGraphCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxGraphViewCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxStylesheetCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxDefaultKeyHandlerCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxDefaultToolbarCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxDefaultPopupMenuCodec.js');
+	mxClient.include(mxClient.basePath+'/js/io/mxEditorCodec.js');
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,17 @@
 {
   "name": "mxgraph",
+  "description": "mxGraph is a fully client side JavaScript diagramming library that uses SVG and HTML for rendering.",
   "version": "3.7.1",
+  "homepage": "https://github.com/jgraph/mxgraph",
+  "author": "JGraph",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jgraph/mxgraph.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jgraph/mxgraph/issues"
+  },
   "main": "./javascript/dist/build.js",
   "scripts": {
     "postinstall": "grunt build"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mxgraph",
+  "version": "3.7.1",
+  "main": "./javascript/dist/build.js",
+  "scripts": {
+    "install": "grunt build"
+  },
+  "dependencies": {
+    "grunt": "^1.0.1",
+    "grunt-contrib-concat": "^1.0.1",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-webpack": "^2.0.1",
+    "webpack": "^2.2.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "3.7.1",
   "main": "./javascript/dist/build.js",
   "scripts": {
-    "install": "grunt build"
+    "postinstall": "grunt build"
   },
   "dependencies": {
     "grunt": "^1.0.1",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-webpack": "^2.0.1",
+    "load-grunt-parent-tasks": "^0.1.1",
+    "load-grunt-tasks": "^3.5.2",
     "webpack": "^2.2.1"
   }
 }


### PR DESCRIPTION
This pull requests creates an npm package called `mxgraph`. It allows the package to be loaded in CommonJS environments such as Webpack using the `require()` function.

There is also an example in `examples/webpack/anchors.html` to show how the package can be included.

Example:

    var mxgrath = require("mxgraph")({
        mxImageBasePath: "./src/images",
        mxBasePath: “./src"
    });
    var mxShape = mxgraph.mxShape;
