### PR TITLE
Stepless scrolling workaround to mouse wheel event

### DIFF
--- a/javascript/examples/grapheditor/www/js/EditorUi.js
+++ b/javascript/examples/grapheditor/www/js/EditorUi.js
@@ -1907,28 +1907,18 @@ EditorUi.prototype.initCanvas = function()
 	
 	mxEvent.addMouseWheelListener(mxUtils.bind(this, function(evt, up)
 	{
-		// Ctrl+wheel (or pinch on touchpad) is a native browser zoom event is OS X
-		// LATER: Add support for zoom via pinch on trackpad for Chrome in OS X
-		if ((mxEvent.isAltDown(evt) || (mxEvent.isControlDown(evt) && !mxClient.IS_MAC) ||
-			graph.panningHandler.isActive()) && (this.dialogs == null || this.dialogs.length == 0))
+			cursorPosition = new mxPoint(mxEvent.getClientX(evt), mxEvent.getClientY(evt));
+			graph.lazyZoom(up);
+			mxEvent.consume(evt);
+	}), {
+		target: graph.container,
+		filter: mxUtils.bind(this, function(evt)
 		{
-			var source = mxEvent.getSource(evt);
-			
-			while (source != null)
-			{
-				if (source == graph.container)
-				{
-					cursorPosition = new mxPoint(mxEvent.getClientX(evt), mxEvent.getClientY(evt));
-					graph.lazyZoom(up);
-					mxEvent.consume(evt);
-			
-					return;
-				}
-				
-				source = source.parentNode;
-			}
-		}
-	}));
+			return (mxEvent.isAltDown(evt) || (mxEvent.isControlDown(evt) && !mxClient.IS_MAC) ||
+				graph.panningHandler.isActive()) && (this.dialogs == null || this.dialogs.length == 0);
+		}),
+		preventDefault: true
+	});
 };
 
 /**


### PR DESCRIPTION
Stepless scrolling is present when using trackpad or mouse that has stepless scroll weel (not in Firefox, because of different event).
This workaround fixes mouse wheel event in mxEvent and a zooming bug in Graph Editor relating this issue.
Target and custom filter had to be implemented to the event, because while zooming in Graph Editor with stepless mouse you need to prevent the default behavior of the event, otherwise scrolling would happen if the movement was too small.

Tested using Google Chrome version 60.0 with trackpad.
Further testing with different browsers, mouses and examples adviced.