### PR TITLE
modify no var variables to prevent them to be global variables and throwing error in a modularized env.

### DIFF
--- a/javascript/examples/grapheditor/www/js/Format.js
+++ b/javascript/examples/grapheditor/www/js/Format.js
@@ -1502,6 +1502,7 @@ ArrangePanel.prototype.addGroupOps = function(div)
 	var cell = graph.getSelectionCell();
 	var ss = this.format.getSelectionState();
 	var count = 0;
+	var btn = null;
 	
 	div.style.paddingTop = '8px';
 	div.style.paddingBottom = '6px';

--- a/javascript/examples/grapheditor/www/js/Graph.js
+++ b/javascript/examples/grapheditor/www/js/Graph.js
@@ -1566,7 +1566,8 @@ Graph.prototype.replacePlaceholders = function(cell, str)
 {
 	var result = [];
 	var last = 0;
-	
+	var match = [];
+
 	while (match = this.placeholderPattern.exec(str))
 	{
 		var val = match[0];

--- a/javascript/examples/grapheditor/www/js/Graph.js
+++ b/javascript/examples/grapheditor/www/js/Graph.js
@@ -6021,7 +6021,7 @@ if (typeof mxVertexHandler != 'undefined')
 		{
 		    if (window.getSelection)
 		    {
-		        sel = window.getSelection();
+		        var sel = window.getSelection();
 		        
 		        if (sel.getRangeAt && sel.rangeCount)
 		        {

--- a/javascript/examples/grapheditor/www/js/Sidebar.js
+++ b/javascript/examples/grapheditor/www/js/Sidebar.js
@@ -1865,6 +1865,7 @@ Sidebar.prototype.createThumb = function(cells, width, height, parent, title, sh
 Sidebar.prototype.createItem = function(cells, title, showLabel, showTitle, width, height, allowCellsInserted)
 {
 	var elt = document.createElement('a');
+	var cells = cells || []
 	elt.setAttribute('href', 'javascript:void(0);');
 	elt.className = 'geItem';
 	elt.style.overflow = 'hidden';
@@ -1886,8 +1887,8 @@ Sidebar.prototype.createItem = function(cells, title, showLabel, showTitle, widt
 
 	this.createThumb(cells, this.thumbWidth, this.thumbHeight, elt, title, showLabel, showTitle, width, height);
 	var bounds = new mxRectangle(0, 0, width, height);
-	
-	if (cells.length > 1 || cells[0].vertex)
+
+	if (cells.length > 1 ||  (cells[0] && cells[0].vertex))
 	{
 		var ds = this.createDragSource(elt, this.createDropHandler(cells, true, allowCellsInserted,
 			bounds), this.createDragPreview(width, height), cells, bounds);


### PR DESCRIPTION
variable without var will be a global variable.

I‘m working on modularizing (use babel & webpack) the graph editor example in our own project, and when i drag a shape to canvas or do some other operation, it will throw  errors because of these (no var) variables.