### PR TITLE
Fix npm package install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "main": "./javascript/dist/build.js",
   "scripts": {
-    "postinstall": "grunt build --base \"$(npm prefix)\" --gruntfile etc/build/Gruntfile.js"
+    "prepublish": "grunt build --base ./ --gruntfile etc/build/Gruntfile.js"
   },
   "dependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
Prepare dist folder before publishing the package to npm registry and publish it in the package.