### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules
+.jshintrc
+.idea/


### PR DESCRIPTION
Npm uses .gitignore file if there is no .npmignore file present. Adding .npmignore file to be able to publish javascript/dist folder.