### PR TITLE
Pre-publish script fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "main": "./javascript/dist/build.js",
   "scripts": {
-    "prepare": "grunt build --base ./ --gruntfile etc/build/Gruntfile.js"
+    "prepublishOnly": "grunt build --base ./ --gruntfile etc/build/Gruntfile.js",
+    "prepublish": "npm run prepublishOnly"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
Prepare "javascript/dist/build.js" file before publishing the package to npm registry.