### PR TITLE
No open positions at the moment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 mxgraph
 =======
 
-Plug : We're looking for [senior JavaScript engineers](https://about.draw.io/draw-io-jobs/) with at least 10 years commercial software experience.
-
 mxGraph is a fully client side JavaScript diagramming library that uses SVG and HTML for rendering. [draw.io](https://www.draw.io) is an example that extends the functionality of this library. The [sources to draw.io](https://github.com/jgraph/draw.io) are also available.
 
 Note this is the release repo. The development repo is on [Bitbucket](https://bitbucket.org/jgraph/mxgraph2). Submit PRs there.


### PR DESCRIPTION
That URL indicates "We do not have any open positions. We did not post the listing on the Remote OK site and they have been asked to remove it"