### PR TITLE
Removed unnecessary dependency

### DIFF
--- a/etc/build/Gruntfile.js
+++ b/etc/build/Gruntfile.js
@@ -1,6 +1,5 @@
 var path = require("path"),
     fs = require("fs"),
-    parentFolderName = path.basename(path.resolve('..')),
     mxClientContent,
     deps;
 
@@ -89,7 +88,7 @@ module.exports = function (grunt) {
     },
   });
 
-  require(parentFolderName === "node_modules" ? "load-grunt-parent-tasks" : "load-grunt-tasks")(grunt);
+  require("load-grunt-tasks")(grunt);
   grunt.registerTask("default", [
     "copy",
     "concat",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-webpack": "^2.0.1",
-    "load-grunt-parent-tasks": "^0.1.1",
     "load-grunt-tasks": "^3.5.2",
     "webpack": "^2.2.1"
   }


### PR DESCRIPTION
`load-grunt-parent-tasks` is no needed anymore because the dist is being generated on publish.