### PR TITLE
Fixed typo in grapheditor example

### DIFF
--- a/javascript/examples/grapheditor/README
+++ b/javascript/examples/grapheditor/README
@@ -1,5 +1,5 @@
 Run com.mxgraph.examples.web.GraphEditor in javascript/examples/grapheditor/java/src
-(in Eclipse) or execute "ant grapheditor-example" in the java directory (using Ant)
+(in Eclipse) or execute "ant grapheditor" in the java directory (using Ant)
 and point your browser to:
 
 http://localhost:8080/javascript/examples/grapheditor/www/index.html


### PR DESCRIPTION
build.xml has <target name="grapheditor"... not "grapheditor-example"