### PR TITLE
Fix missing var sb = this;

### DIFF
--- a/javascript/examples/grapheditor/www/js/Sidebar.js
+++ b/javascript/examples/grapheditor/www/js/Sidebar.js
@@ -989,6 +989,9 @@ Sidebar.prototype.addBasicPalette = function(dir)
  */
 Sidebar.prototype.addMiscPalette = function(expand)
 {
+	// Avoids having to bind all functions to "this"
+	var sb = this;
+	
 	var lineTags = 'line lines connector connectors connection connections arrow arrows '
 	
 	var fns = [


### PR DESCRIPTION
Fix missing var sb = this; in Sidebar.prototype.addMiscPalette function in Sidebar.js
Bug screenshot: https://ibb.co/mUjetT