### PR TITLE
 Allow connecting to same point on different cells

### DIFF
--- a/javascript/src/js/handler/mxConnectionHandler.js
+++ b/javascript/src/js/handler/mxConnectionHandler.js
@@ -1744,7 +1744,8 @@ mxConnectionHandler.prototype.mouseUp = function(sender, me)
 			}
 
 			// If the cells differ, or if they are the same but the constraints differ, connect
-			if (target.getId() != source.getId() || this.checkConstraints(c1, c2)) {
+			var differentCells = (target==null || source==null || target.getId() != source.getId());
+			if (differentCells || this.checkConstraints(c1, c2)) {
 				this.connect(source, target, me.getEvent(), me.getCell());
 			}
 		}

--- a/javascript/src/js/handler/mxConnectionHandler.js
+++ b/javascript/src/js/handler/mxConnectionHandler.js
@@ -1726,8 +1726,8 @@ mxConnectionHandler.prototype.mouseUp = function(sender, me)
 		var c1 = this.sourceConstraint;
 		var c2 = this.constraintHandler.currentConstraint;
 		
-		// Inserts the edge if no validation error exists and if constraints differ
-		if (this.error == null && this.checkConstraints(c1, c2))
+		// Inserts the edge if no validation error exists
+		if (this.error == null)
 		{
 			var source = (this.previous != null) ? this.previous.cell : null;
 			var target = null;
@@ -1742,8 +1742,11 @@ mxConnectionHandler.prototype.mouseUp = function(sender, me)
 			{
 				target = this.currentState.cell;
 			}
-			
-			this.connect(source, target, me.getEvent(), me.getCell());
+
+			// If the cells differ, or if they are the same but the constraints differ, connect
+			if (target.getId() != source.getId() || this.checkConstraints(c1, c2)) {
+				this.connect(source, target, me.getEvent(), me.getCell());
+			}
 		}
 		else
 		{


### PR DESCRIPTION
To reproduce: run the GraphEditor example, then place two rectangles. Try to connect a point on one rectangle to the same point on another. The connection fails because checkConstraints is detecting that the constraints have the same relative point, despite being on different shapes.

This fix is implemented by allowing the connection if the cells differ, and only checking the constraints if the cells are the dame.