### PR TITLE
Fix Date for 4.0.0 Release in ChangeLog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-11-MAR-2018: 4.0.0
+11-MAR-2019: 4.0.0
 
 - mxClient.IS_SVG is true for all non-VML browsers
 - Adds mxCellState.invalidStyle


### PR DESCRIPTION
With a quick look at https://www.jgraph.com/mxchangelog.html it appeared there hasn't been a release in quite some time. Looking more closely at the repository made me realize this was a typo.