### PR TITLE
Feature/merge from drawio

### DIFF
--- a/javascript/mxClient.js
+++ b/javascript/mxClient.js
@@ -9731,8 +9731,10 @@ var mxEvent =
 	 * 
 	 * funct - Handler function that takes the event argument and a boolean up
 	 * argument for the mousewheel direction.
+     *
+     * elem - the specified DOM element, default window
 	 */
-	addMouseWheelListener: function(funct)
+	addMouseWheelListener: function(funct, elem)
 	{
 		if (funct != null)
 		{
@@ -9763,17 +9765,20 @@ var mxEvent =
 					funct(evt, delta > 0);
 				}
 			};
-	
-			// Webkit has NS event API, but IE event name and details 
-			if (mxClient.IS_NS && document.documentMode == null)
-			{
-				var eventName = (mxClient.IS_SF || 	mxClient.IS_GC) ? 'mousewheel' : 'DOMMouseScroll';
-				mxEvent.addListener(window, eventName, wheelHandler);
-			}
-			else
-			{
-				mxEvent.addListener(document, 'mousewheel', wheelHandler);
-			}
+			
+            var eventName = 'mousewheel';
+            var observableElem;
+            // Webkit has NS event API, but IE event name and details
+            if (mxClient.IS_NS && document.documentMode == null)
+            {
+                eventName = (mxClient.IS_SF || mxClient.IS_GC) ? eventName : 'DOMMouseScroll';
+                observableElem = elem ? elem : window;
+            }
+            else
+            {
+                observableElem = document;
+            }
+            mxEvent.addListener(observableElem, eventName, wheelHandler);
 		}
 	},
 	

--- a/javascript/mxClient.js
+++ b/javascript/mxClient.js
@@ -9731,8 +9731,8 @@ var mxEvent =
 	 * 
 	 * funct - Handler function that takes the event argument and a boolean up
 	 * argument for the mousewheel direction.
-     *
-     * elem - the specified DOM element, default window
+	 *
+	 * elem - the specified DOM element, default window
 	 */
 	addMouseWheelListener: function(funct, elem)
 	{
@@ -9765,20 +9765,20 @@ var mxEvent =
 					funct(evt, delta > 0);
 				}
 			};
-			
-            var eventName = 'mousewheel';
-            var observableElem;
-            // Webkit has NS event API, but IE event name and details
-            if (mxClient.IS_NS && document.documentMode == null)
-            {
-                eventName = (mxClient.IS_SF || mxClient.IS_GC) ? eventName : 'DOMMouseScroll';
-                observableElem = elem ? elem : window;
-            }
-            else
-            {
-                observableElem = document;
-            }
-            mxEvent.addListener(observableElem, eventName, wheelHandler);
+
+			var eventName = 'mousewheel';
+			var observableElem;
+			// Webkit has NS event API, but IE event name and details
+			if (mxClient.IS_NS && document.documentMode == null)
+			{
+				eventName = (mxClient.IS_SF || mxClient.IS_GC) ? eventName : 'DOMMouseScroll';
+				observableElem = elem ? elem : window;
+			}
+			else
+			{
+				observableElem = document;
+			}
+			mxEvent.addListener(observableElem, eventName, wheelHandler);
 		}
 	},
 	


### PR DESCRIPTION
Add second argument for addMouseWheelListener

Because I see code from jgraph/drawio and build of /etc/mxgraph/mxClient

https://github.com/jgraph/drawio/blob/master/src/main/webapp/js/mxgraph/EditorUi.js#L2097



![image](https://user-images.githubusercontent.com/47079939/59758346-60e6d100-9296-11e9-8ae3-5bba3544b619.png)
