### PR TITLE
Fix edge label position value problem

### DIFF
--- a/java/src/com/mxgraph/view/mxGraphView.java
+++ b/java/src/com/mxgraph/view/mxGraphView.java
@@ -1760,8 +1760,8 @@ public class mxGraphView extends mxEventSource
 
 				// Constructs the relative point for the label
 				return new mxPoint(
-						Math.round(((totalLength / 2 - length - projlen) / totalLength)
-								* -2), Math.round(yDistance / scale));
+						((totalLength / 2 - length - projlen) / totalLength)
+								* -2, yDistance / scale);
 			}
 		}
 


### PR DESCRIPTION
Edge geometry x,y coordinates are used position label along the edge line relative to the edge: x=offset along the line, y=distance from the line. The X is a double precision value within -1.0 to 1.0 where 0.0 means the the center of the line. Bug: relative point calculation always constructed x values -1.0, 0, 1.0, but none between them.