### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,7 +10,6 @@ build.sh
 classes
 docs/
 dotnet/
-etc/
 index.html
 java/
 javascript/debug/

--- a/.npmignore
+++ b/.npmignore
@@ -16,7 +16,6 @@ javascript/debug/
 javascript/devel/
 javascript/examples/
 javascript/index.html
-javascript/src/js/
 mxgraph-dotnet.*suo
 php/
 pom.xml


### PR DESCRIPTION
Removed etc and javascript/src/js directories from ignore.

Gruntfile.js under etc/build directory and javascript source are needed to be able to build mxgraph as npm package (since it is not shipped with npm package artifacts)